### PR TITLE
Add `Timer.Engine` and `Timer.Actor`.

### DIFF
--- a/.github/workflows/library-check.yaml
+++ b/.github/workflows/library-check.yaml
@@ -46,3 +46,20 @@ jobs:
   #
   # Add any custom jobs you need below this comment.
   # The area above this comment is reserved for future standard jobs.
+
+  # Run some integration tests using a binary that prints ticks on a timer.
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: savi-lang/action-install@v1.0.0
+      - run: savi deps update --for integration-ticker
+      - run: savi build integration-ticker
+
+      - name: Check timer ticks output
+        run: |
+          bin/integration-ticker | tee /tmp/integration-ticker-output
+          printf "number of ticks: "
+          wc -l < /tmp/integration-ticker-output | grep 50
+          printf "number of accurate ticks: "
+          cat /tmp/integration-ticker-output | grep 100 | wc -l | grep 50

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright DATE COPYRIGHT_HOLDER
+Copyright 2022 Joe Eli McIlvain
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-A base repository for Savi language libraries, with common CI actions configured.
+# Timer
 
-See the [Guide](https://github.com/savi-lang/base-standard-library/wiki/Guide) for details on how it works and how to use it for your own libraries.
+Asynchronous time-based eventing for the Savi standard library.

--- a/manifest.savi
+++ b/manifest.savi
@@ -1,0 +1,22 @@
+:manifest lib Timer
+  :sources "src/*.savi"
+
+  :dependency Time v0
+    :from "github:savi-lang/Time"
+
+:manifest bin "spec"
+  :copies Timer
+  :sources "spec/*.savi"
+
+  :dependency Spec v0
+    :from "github:savi-lang/Spec"
+    :depends on Map
+
+  :transitive dependency Map v0
+    :from "github:savi-lang/Map"
+
+// A simple program used for integration testing, which prints a series of
+// numbers showing how much time has passed between ticks, then exits.
+:manifest bin "integration-ticker"
+  :copies Timer
+  :sources "spec/integration/ticker/*.savi"

--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -1,0 +1,3 @@
+:actor Main
+  :new (env Env)
+    env.out.print("TODO: tests")

--- a/spec/integration/ticker/Main.savi
+++ b/spec/integration/ticker/Main.savi
@@ -1,0 +1,32 @@
+:actor Main
+  :new (env Env)
+    Ticker.new(env)
+
+:actor Ticker
+  :is Timer.Actor
+  :let env Env
+  :let timer Timer.Engine
+
+  // Print 50 ticks, with 100ms per tick.
+  :const finish_tick_count U64: 50
+  :const tick_milliseconds U64: 100
+  :var tick_count U64: 0
+
+  :new (@env)
+    @timer = Timer.Engine.new(@, Time.Duration.milliseconds(@tick_milliseconds))
+
+  :fun ref timer_react @
+    // Print the number of milliseconds since the last tick, rounded to the
+    // nearest 10 milliseconds. We round this way because we want to be
+    // able to show a stable number across each tick for testing, while
+    // the elapsed time sometimes varies at the individual millisecond level.
+    try (
+      rounded_milliseconds = (@timer.elapsed.total_milliseconds! + 5) / 10 * 10
+      @env.out.print(Inspect[rounded_milliseconds])
+    )
+
+    // Dispose of the timer after it has done the requested number of ticks.
+    @tick_count += 1
+    if (@tick_count >= @finish_tick_count) @dispose
+
+    @

--- a/src/Timer.Actor.savi
+++ b/src/Timer.Actor.savi
@@ -1,0 +1,10 @@
+:trait tag Timer.Actor
+  :is AsioEvent.Actor
+  :fun timer @->(Timer.Engine)
+  :fun ref timer_react @
+
+  :be dispose
+    @timer.dispose
+
+  :be _asio_event(event AsioEvent)
+    @timer.react(event) -> (@timer_react)

--- a/src/Timer.Engine.savi
+++ b/src/Timer.Engine.savi
@@ -1,0 +1,43 @@
+:class Timer.Engine
+  :let _event_id AsioEvent.ID
+  :var _elapsed_nanos U64: 0
+  :var _interval_nanos U64
+  :var _last_react_nanos U64
+  :var _next_react_nanos U64
+
+  :new (actor Timer.Actor, interval Time.Duration)
+    @_interval_nanos = nanos = try (interval.total_nanoseconds! | U64.max_value)
+    @_last_react_nanos = Time.Measure.current_nanoseconds
+    @_next_react_nanos = @_last_react_nanos + @_interval_nanos
+    @_event_id =
+      _FFI.pony_asio_event_create(actor, 0, AsioEvent.Flags.timer, nanos, True)
+
+  :fun ref "interval="(interval Time.Duration)
+    @_interval_nanos = try (interval.total_nanoseconds! | U64.max_value)
+    @_next_react_nanos = Time.Measure.current_nanoseconds + @_interval_nanos
+    _FFI.pony_asio_event_setnsec(@_event_id, @_interval_nanos)
+
+  :fun ref dispose
+    _FFI.pony_asio_event_unsubscribe(@_event_id)
+
+  :: The time that has elapsed since the last firing of the timer.
+  :: On the first firing of the timer, it indicates the time since creation.
+  :: Immediately after creation (before the first firing) it is zero.
+  :fun elapsed: Time.Duration.nanoseconds(@_elapsed_nanos)
+
+  :fun ref react(event AsioEvent)
+    case (
+    | event.is_disposable |
+      _FFI.pony_asio_event_destroy(event.id)
+    | event.id === @_event_id  |
+      current = Time.Measure.current_nanoseconds
+      @_elapsed_nanos = current - @_last_react_nanos
+      @_last_react_nanos = current
+
+      yield None
+
+      @_next_react_nanos += @_interval_nanos
+      wait_nanos =
+        try (@_next_react_nanos -! Time.Measure.current_nanoseconds | 1)
+      _FFI.pony_asio_event_setnsec(event.id, wait_nanos)
+    )

--- a/src/_FFI.savi
+++ b/src/_FFI.savi
@@ -1,0 +1,21 @@
+:module _FFI
+  :ffi pony_asio_event_create(
+    actor AsioEvent.Actor
+    fd U32
+    flags U32
+    nsec U64
+    noisy Bool
+  ) AsioEvent.ID
+
+  :ffi pony_asio_event_setnsec(
+    event_id AsioEvent.ID
+    nsec U64
+  ) U32
+
+  :ffi pony_asio_event_unsubscribe(
+    event_id AsioEvent.ID
+  ) None
+
+  :ffi pony_asio_event_destroy(
+    event_id AsioEvent.ID
+  ) None


### PR DESCRIPTION
These can be used to run a single timer in an actor, using the ASIO eventing system of the runtime to trigger the actor to run at the specified interval.

See #2 for future related work to allow a single actor to host multiple timers.