### PR TITLE
Update for latest Savi syntax.

### DIFF
--- a/spec/integration/ticker/Main.savi
+++ b/spec/integration/ticker/Main.savi
@@ -27,6 +27,6 @@
 
     // Dispose of the timer after it has done the requested number of ticks.
     @tick_count += 1
-    if (@tick_count >= @finish_tick_count) @dispose
+    if @tick_count >= @finish_tick_count @dispose
 
     @


### PR DESCRIPTION
Many parens that were previously necessary are now unnecessary.